### PR TITLE
Fix mod integration with integrated server

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,7 @@
   "contact": {},
   "license": "LGPL-3.0",
   "icon": "assets/fireball/icon.png",
-  "environment": "server",
+  "environment": "*",
   "entrypoints": {
     "main": [
       "com.podium868909.fireball.Fireball"


### PR DESCRIPTION
Fixes #1

Change the `environment` field in `fabric.mod.json` to allow the mod to be loaded on both client and server sides.

* Change the `environment` field from `"server"` to `"*"` to enable the mod to be loaded on both client and server sides.

